### PR TITLE
Support strict dynamic csp

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,22 @@ By default, Hydrogen sets up [Content Security Policy](https://shopify.dev/docs/
 [csp.js](apps/shogun/csp.js) shows the default Shogun config.
 
 If you need to add any other domains you can add them here or make an additional config that you merge with this Shogun config.
+
+## Does Shogun support 'strict-dynamic' in Content Security Policy (CSP)?
+
+Yes. Shogun now fully supports the 'strict-dynamic' directive in your CSP. This means your site can maintain a high level of security while still loading dynamic content and scripts from Shogun. As long as your implementation includes a valid nonce, Shogun's scripts will load and function correctly without requiring unsafe configurations.
+
+### How to enable it:
+
+To activate 'strict-dynamic', open the [csp.js](apps/shogun/csp.js) file in your Hydrogen project and locate the SHOGUN_CSP_DIRECTIVES object. Inside the defaultSrc array, comment out or remove 'unsafe-inline', and uncomment 'strict-dynamic'. Your updated defaultSrc should look like this:
+
+```javascript
+defaultSrc: [
+  // -- Start: CSP settings for src
+  "'strict-dynamic'", // ✅ Enable this
+  // "'unsafe-inline'", // ❌ Disable this
+
+  "'self'",
+  // ...
+],
+```

--- a/app/routes/($locale).shogun.$.jsx
+++ b/app/routes/($locale).shogun.$.jsx
@@ -1,4 +1,5 @@
 import { useLoaderData } from '@remix-run/react';
+import { useNonce } from '@shopify/hydrogen';
 import { ShogunPage, getShogunPage } from '~/shogun';
 
 // If you host this route under a different path, update the BASE_PATH
@@ -36,6 +37,15 @@ export async function loader({ request, context }) {
 
 export default function Shogun() {
   const pageData = useLoaderData();
+  const nonce = useNonce();
 
-  return <ShogunPage pageData={pageData} />;
+  // Inject nonce in script tags for CSP compliance
+  const processedHtml = nonce
+  ? pageData.replace(
+      /<script(?![^>]*\bnonce=)([^>]*)>/gi,
+      `<script nonce="${nonce}"$1>`
+    )
+  : pageData;
+
+  return <ShogunPage pageData={processedHtml} />;
 }

--- a/app/shogun/csp.js
+++ b/app/shogun/csp.js
@@ -12,6 +12,7 @@ export const SHOGUN_CSP_DIRECTIVES = {
 
     'https://cdn.getshogun.com',
     'https://i.shgcdn.com',
+    'https://a.shgcdn2.com',
     'https://views.unsplash.com',
     'https://fonts.gstatic.com',
     'https://www.youtube.com',
@@ -27,6 +28,7 @@ export const SHOGUN_CSP_DIRECTIVES = {
 
     'https://cdn.getshogun.com',
     'https://i.shgcdn.com',
+    'https://a.shgcdn2.com',
     'https://fonts.googleapis.com',
   ],
 };

--- a/app/shogun/csp.js
+++ b/app/shogun/csp.js
@@ -3,6 +3,11 @@
  */
 export const SHOGUN_CSP_DIRECTIVES = {
   defaultSrc: [
+    // -- Start: CSP settings for src
+    "'unsafe-inline'",
+    // "'strict-dynamic'",
+    // -- End: CSP settings for src
+
     // -- start: shopify defaults
     "'self'",
     'https://cdn.shopify.com',
@@ -20,9 +25,10 @@ export const SHOGUN_CSP_DIRECTIVES = {
     'https://maxcdn.bootstrapcdn.com',
   ],
   styleSrc: [
+    "'unsafe-inline'",
+
     // -- start: shopify defaults
     "'self'",
-    "'unsafe-inline'",
     'https://cdn.shopify.com',
     // -- end: shopify defaults
 


### PR DESCRIPTION
### ✅ Add support for 'strict-dynamic' CSP in Shogun integration

🧩 **Problem**
A customer reported that their Hydrogen storefront uses [Yotpo](https://www.yotpo.com/) and enforces a strict Content Security Policy (CSP) with `'strict-dynamic'`.

However, Shogun's integration was breaking their CSP because:

- Shogun injects `<script>` tags via dangerouslySetInnerHTML
- Those scripts lacked the required nonce, causing the browser to block them
- `'strict-dynamic'` ignores domain-based allowlists and only permits scripts with a valid nonce


🛠 **Root Cause**
The CSP used by the customer contained `'strict-dynamic'` in `script-src`, which requires all scripts to:

- Include a `nonce`, or
- Be dynamically created by a trusted (`nonced`) script

Our Shogun integration was not injecting `nonce` attributes into the rendered script tags, resulting in a CSP violation.

✅ **Fix**

- Added support for injecting a nonce into all `<script>` tags inside pageData
- Ensured that the nonce is passed from the server to the route loader and then into the component
- Updated the Shogun route to inject the nonce using a `replace()` before rendering HTML

📌 **How to Enable `'strict-dynamic'`**

In `shogun/csp.js`, update your CSP config:

```
defaultSrc: [
  "'strict-dynamic'", // ✅ Required
  "'self'",
  'https://cdn.getshogun.com',
  'https://a.shgcdn2.com',
  ...
],
```

✅ **Result**

After these changes:

- Customers can enable `'strict-dynamic'` in their CSP
- All Shogun script tags will receive the correct nonce
- Compatibility with modern CSP configurations is now supported